### PR TITLE
Update api.py

### DIFF
--- a/custom_components/remeha_modbus/api/api.py
+++ b/custom_components/remeha_modbus/api/api.py
@@ -79,6 +79,9 @@ class DeviceBoardType(Enum):
 
     EEC = int("1b", 16)
     """Motherboard for gas boilers like GAS 120 Ace"""
+    
+    EHC_ALT = int("21", 16)
+    """Unknown/alternate heatpump mainboard (seen on Confida)"""
 
     GATEWAY = int("1e", 16)
     """A gateway, for example GTW-08 (modbus gateway)"""
@@ -90,6 +93,7 @@ class DeviceBoardType(Enum):
             DeviceBoardType.CU_GH,
             DeviceBoardType.CU_OH,
             DeviceBoardType.EHC,
+            DeviceBoardType.EHC_ALT,
             DeviceBoardType.EEC,
         ]
 


### PR DESCRIPTION
I have a Remeha Confida with the 50E indoor unit.
It is identified as board 33, which is not supported by the integration.

I edited the api.py:

Now a few entities are already being recognized, although not all of them are correct yet.

If you like, I’d be happy to support you with further development.

I am using a USR-DR134 as the Modbus gateway.

<img width="335" height="405" alt="Bildschirmfoto 2026-04-22 um 13 48 29" src="https://github.com/user-attachments/assets/520ed4da-e321-4bf3-96d4-a48d3295b2b5" />
<img width="332" height="767" alt="Bildschirmfoto 2026-04-22 um 13 48 17" src="https://github.com/user-attachments/assets/ccccfa31-bc2d-4a51-b341-77ae3767e713" />
<img width="335" height="774" alt="Bildschirmfoto 2026-04-22 um 13 48 03" src="https://github.com/user-attachments/assets/83ad7977-3149-4852-bfa0-cc5c4dfda74c" />
<img width="355" height="265" alt="Bildschirmfoto 2026-04-22 um 13 47 51" src="https://github.com/user-attachments/assets/6d34a4f1-9a33-4a85-8dc7-b91e49611d1f" />
<img width="591" height="601" alt="Bildschirmfoto 2026-04-22 um 13 47 19" src="https://github.com/user-attachments/assets/2536a402-6c1b-45dc-a88a-0e26639c7e33" />
<img width="738" height="282" alt="Bildschirmfoto 2026-04-22 um 13 47 09" src="https://github.com/user-attachments/assets/265e57d5-57c3-47d6-a720-3585fc0e36aa" />
<img width="516" height="409" alt="Bildschirmfoto 2026-04-22 um 13 46 30" src="https://github.com/user-attachments/assets/dbccc26c-1ed3-467a-9391-26e5b526b5ce" />
