### PR TITLE
Add writable appliance settings: summer/winter threshold, CH and cooling

### DIFF
--- a/custom_components/remeha_modbus/number.py
+++ b/custom_components/remeha_modbus/number.py
@@ -12,7 +12,13 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from custom_components.remeha_modbus.api import DeviceInstance, RemehaApi
 from custom_components.remeha_modbus.api.climate_zone import ClimateZone
-from custom_components.remeha_modbus.const import DOMAIN, TEMPERATURE_STEP, Limits, ZoneRegisters
+from custom_components.remeha_modbus.const import (
+    DOMAIN,
+    TEMPERATURE_STEP,
+    Limits,
+    MetaRegisters,
+    ZoneRegisters,
+)
 from custom_components.remeha_modbus.coordinator import RemehaUpdateCoordinator
 
 _LOGGER = logging.getLogger(__name__)
@@ -26,16 +32,26 @@ async def async_setup_entry(
     api: RemehaApi = entry.runtime_data["api"]
     coordinator: RemehaUpdateCoordinator = entry.runtime_data["coordinator"]
 
+    entities: list[NumberEntity] = []
+
+    mainboards: list[DeviceInstance] = coordinator.get_devices(lambda device: device.is_mainboard())
+    if mainboards:
+        entities.append(
+            RemehaSummerWinterNumber(
+                api=api, coordinator=coordinator, parent_device_id=mainboards[0].id
+            )
+        )
+
     climates: list[ClimateZone] = coordinator.get_climates(lambda c: c.is_domestic_hot_water())
     if climates:
-        async_add_entities(
-            [
-                DhwHysteresisEntity(api=api, coordinator=coordinator, zone_id=climate.id)
-                for climate in climates
-            ]
+        entities.extend(
+            DhwHysteresisEntity(api=api, coordinator=coordinator, zone_id=climate.id)
+            for climate in climates
         )
     else:
         _LOGGER.debug("No DHW climates found so not adding any DhwHysteresis entities.")
+
+    async_add_entities(entities)
 
 
 class DhwHysteresisEntity(CoordinatorEntity[RemehaUpdateCoordinator], NumberEntity):
@@ -99,6 +115,76 @@ class DhwHysteresisEntity(CoordinatorEntity[RemehaUpdateCoordinator], NumberEnti
             return None
 
         device_instance: DeviceInstance | None = self.coordinator.get_device(id=zone.owning_device)
+        return (
+            DeviceInfo(
+                identifiers={(DOMAIN, str(device_instance.article_number))},
+                hw_version=f"HW{device_instance.hw_version[0]:02d}.{device_instance.hw_version[1]:02d}",
+                manufacturer="Remeha",
+                model=str(device_instance.board_category),
+                sw_version=f"SW{device_instance.sw_version[0]:02d}.{device_instance.sw_version[1]:02d}",
+            )
+            if device_instance is not None
+            else None
+        )
+
+
+class RemehaSummerWinterNumber(CoordinatorEntity[RemehaUpdateCoordinator], NumberEntity):
+    """Number entity for the summer/winter outdoor temperature threshold (parameter AP073).
+
+    Above this outside temperature the appliance switches to summer mode and stops heating.
+    """
+
+    _attr_has_entity_name = True
+    _attr_device_class = NumberDeviceClass.TEMPERATURE
+    _attr_native_min_value = 10.0
+    _attr_native_max_value = 30.5
+    _attr_native_step = 0.5
+    _attr_native_unit_of_measurement = "°C"
+    _attr_should_poll = False
+    _attr_translation_key = DOMAIN
+
+    def __init__(
+        self, api: RemehaApi, coordinator: RemehaUpdateCoordinator, parent_device_id: int | None
+    ):
+        """Create a new summer/winter threshold entity."""
+
+        super().__init__(coordinator)
+
+        self._api: RemehaApi = api
+        self._parent_device_id = parent_device_id
+        self._attr_unique_id = "summer_winter"
+        self._attr_name = "summer_winter"
+
+    @property
+    def native_value(self) -> float:
+        """Return the current summer/winter threshold."""
+
+        return cast(float, self.coordinator.get_appliance().summer_winter)
+
+    async def async_set_native_value(self, value: float) -> None:
+        """Update the summer/winter threshold."""
+
+        await self._api.async_write_variable(variable=MetaRegisters.SUMMER_WINTER, value=value)
+
+        # Update the value so users don't have to wait until the next sync.
+        self.coordinator.get_appliance().summer_winter = value
+        self.async_write_ha_state()
+
+    @property
+    def device_info(self) -> DeviceInfo | None:
+        """Return information about the device this instance belongs to.
+
+        Returns
+            `DeviceInfo | None`: The device info, or `None` if this instance is not owned by any device.
+
+        """
+
+        if self._parent_device_id is None:
+            return None
+
+        device_instance: DeviceInstance | None = self.coordinator.get_device(
+            id=self._parent_device_id
+        )
         return (
             DeviceInfo(
                 identifiers={(DOMAIN, str(device_instance.article_number))},

--- a/custom_components/remeha_modbus/switch.py
+++ b/custom_components/remeha_modbus/switch.py
@@ -14,10 +14,14 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import STATE_ON
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import issue_registry as ir
+from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.restore_state import RestoreEntity
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from propcache.api import cached_property
 
+from custom_components.remeha_modbus.api import DeviceInstance, RemehaApi
+from custom_components.remeha_modbus.api.appliance import CoolingType
 from custom_components.remeha_modbus.blend.scheduler.helpers import scheduler_is_installed
 from custom_components.remeha_modbus.const import (
     DOMAIN,
@@ -25,6 +29,7 @@ from custom_components.remeha_modbus.const import (
     ISSUE_HEATPUMP_MANAGED_SCHEDULES_LEARN_MORE_URL,
     ISSUE_HEATPUMP_MANAGED_SCHEDULES_OFF,
     SWITCH_SCHEDULE_SYNC,
+    MetaRegisters,
 )
 from custom_components.remeha_modbus.coordinator import RemehaUpdateCoordinator
 from custom_components.remeha_modbus.helpers.entities import get_climate_entity_id
@@ -35,12 +40,23 @@ _LOGGER = logging.getLogger(__name__)
 async def async_setup_entry(
     hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
 ) -> None:
-    """Create the sensor entities based on the given config entry."""
+    """Create the switch entities based on the given config entry."""
+
+    api: RemehaApi = entry.runtime_data["api"]
+    coordinator: RemehaUpdateCoordinator = entry.runtime_data["coordinator"]
+    mainboards: list[DeviceInstance] = coordinator.get_devices(lambda device: device.is_mainboard())
+    parent_device_id: int | None = mainboards[0].id if mainboards else None
 
     async_add_entities(
         [
             RemehaScheduleSynchronizationSwitch(SWITCH_SCHEDULE_SYNC, entry),
             RemehaHeatpumpManagedSchedulesSwitch(HEATPUMP_MANAGED_SCHEDULES, entry),
+            RemehaChEnabledSwitch(
+                api=api, coordinator=coordinator, parent_device_id=parent_device_id
+            ),
+            RemehaCoolingEnabledSwitch(
+                api=api, coordinator=coordinator, parent_device_id=parent_device_id
+            ),
         ]
     )
 
@@ -192,3 +208,142 @@ class RemehaHeatpumpManagedSchedulesSwitch(RemehaModbusSwitch):
             severity=ir.IssueSeverity.WARNING,
             translation_key="heatpump_managed_schedules_turned_off",
         )
+
+
+class RemehaApplianceSwitch(CoordinatorEntity[RemehaUpdateCoordinator], SwitchEntity):
+    """Base class for appliance-level switches backed by a modbus register."""
+
+    _attr_has_entity_name = True
+    _attr_should_poll = False
+    _attr_device_class = SwitchDeviceClass.SWITCH
+
+    def __init__(
+        self,
+        api: RemehaApi,
+        coordinator: RemehaUpdateCoordinator,
+        parent_device_id: int | None,
+        name: str,
+    ):
+        """Create a new appliance switch."""
+
+        super().__init__(coordinator=coordinator)
+
+        self._api = api
+        self._parent_device_id = parent_device_id
+        self._attr_name = name
+        self._attr_unique_id = name
+
+    @property
+    def translation_key(self) -> str:
+        """The translation key."""
+
+        return cast(str, self.name)
+
+    @property
+    def device_info(self) -> DeviceInfo | None:
+        """Return information about the device this switch belongs to.
+
+        Returns
+            `DeviceInfo | None`: The device info, or `None` if this switch is not owned by any device.
+
+        """
+
+        if self._parent_device_id is None:
+            return None
+
+        device_instance: DeviceInstance | None = self.coordinator.get_device(
+            id=self._parent_device_id
+        )
+        return (
+            DeviceInfo(
+                identifiers={(DOMAIN, str(device_instance.article_number))},
+                hw_version=f"HW{device_instance.hw_version[0]:02d}.{device_instance.hw_version[1]:02d}",
+                manufacturer="Remeha",
+                model=str(device_instance.board_category),
+                sw_version=f"SW{device_instance.sw_version[0]:02d}.{device_instance.sw_version[1]:02d}",
+            )
+            if device_instance is not None
+            else None
+        )
+
+
+class RemehaChEnabledSwitch(RemehaApplianceSwitch):
+    """Switch that enables/disables central heating demand processing (parameter AP016)."""
+
+    def __init__(
+        self, api: RemehaApi, coordinator: RemehaUpdateCoordinator, parent_device_id: int | None
+    ):
+        """Create the central heating switch."""
+
+        super().__init__(
+            api=api,
+            coordinator=coordinator,
+            parent_device_id=parent_device_id,
+            name="ch_enabled",
+        )
+
+    @property
+    def is_on(self) -> bool:
+        """Return whether central heating demand processing is enabled."""
+
+        return self.coordinator.get_appliance().ch_enabled
+
+    async def async_turn_on(self, **kwargs: Any) -> None:
+        """Enable central heating demand processing."""
+
+        await self._async_set_enabled(enabled=True)
+
+    async def async_turn_off(self, **kwargs: Any) -> None:
+        """Disable central heating demand processing."""
+
+        await self._async_set_enabled(enabled=False)
+
+    async def _async_set_enabled(self, enabled: bool) -> None:
+        await self._api.async_write_variable(variable=MetaRegisters.CH_ENABLED, value=enabled)
+
+        # Reflect the change immediately, until the next coordinator refresh.
+        self.coordinator.get_appliance().ch_enabled = enabled
+        self.async_write_ha_state()
+
+
+class RemehaCoolingEnabledSwitch(RemehaApplianceSwitch):
+    """Switch that enables/disables cooling (parameter AP028).
+
+    Turning the switch on selects active cooling; turning it off disables cooling.
+    """
+
+    def __init__(
+        self, api: RemehaApi, coordinator: RemehaUpdateCoordinator, parent_device_id: int | None
+    ):
+        """Create the cooling switch."""
+
+        super().__init__(
+            api=api,
+            coordinator=coordinator,
+            parent_device_id=parent_device_id,
+            name="cooling_enabled",
+        )
+
+    @property
+    def is_on(self) -> bool:
+        """Return whether cooling is enabled."""
+
+        return self.coordinator.get_appliance().cooling_type is not CoolingType.OFF
+
+    async def async_turn_on(self, **kwargs: Any) -> None:
+        """Enable active cooling."""
+
+        await self._async_set_cooling(CoolingType.ACTIVE_COOLING)
+
+    async def async_turn_off(self, **kwargs: Any) -> None:
+        """Disable cooling."""
+
+        await self._async_set_cooling(CoolingType.OFF)
+
+    async def _async_set_cooling(self, cooling_type: CoolingType) -> None:
+        await self._api.async_write_variable(
+            variable=MetaRegisters.COOLING_ENABLED, value=cooling_type
+        )
+
+        self.coordinator.get_appliance().cooling_type = cooling_type
+        self.async_write_ha_state()

--- a/tests/test_number.py
+++ b/tests/test_number.py
@@ -21,7 +21,8 @@ async def test_climates(hass: HomeAssistant, mock_modbus_client, mock_config_ent
         await setup_platform(hass=hass, config_entry=mock_config_entry)
         await hass.async_block_till_done()
 
-        assert len(hass.states.async_all(domain_filter="number")) == 1
+        # One DhwHysteresisEntity + one appliance-level RemehaSummerWinterNumber.
+        assert len(hass.states.async_all(domain_filter="number")) == 2
 
 
 @pytest.mark.parametrize("mock_modbus_client", ["modbus_store.json"], indirect=True)
@@ -57,6 +58,38 @@ async def test_dhw_hysteresis(hass: HomeAssistant, mock_modbus_client, mock_conf
         hysteresis = hass.states.get(hysteresis.entity_id)
         assert hysteresis is not None
         assert hysteresis.state == "20.0"
+
+
+@pytest.mark.parametrize("mock_modbus_client", ["modbus_store.json"], indirect=True)
+async def test_summer_winter(hass: HomeAssistant, mock_modbus_client, mock_config_entry):
+    """Test the appliance summer/winter threshold number entity (AP073)."""
+
+    api = get_api(mock_modbus_client=mock_modbus_client)
+    with patch(
+        "custom_components.remeha_modbus.api.RemehaApi.create",
+        new=lambda *args, **kwargs: api,
+    ):
+        await setup_platform(hass=hass, config_entry=mock_config_entry)
+        await hass.async_block_till_done()
+
+        summer_winter = hass.states.get("number.remeha_modbus_test_hub_summer_winter")
+        assert summer_winter is not None
+        assert summer_winter.state == "22.0"
+        assert summer_winter.domain == "number"
+
+        await hass.services.async_call(
+            domain=NumberDomain,
+            service="set_value",
+            service_data={
+                "entity_id": summer_winter.entity_id,
+                "value": 25.0,
+            },
+            blocking=True,
+        )
+
+        summer_winter = hass.states.get(summer_winter.entity_id)
+        assert summer_winter is not None
+        assert summer_winter.state == "25.0"
 
 
 @pytest.mark.parametrize("mock_modbus_client", ["modbus_store_no_dhw_climate.json"], indirect=True)

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -25,3 +25,36 @@ async def test_switch(hass: HomeAssistant, mock_modbus_client, mock_config_entry
             state = hass.states.get(f"{SwitchDomain}.{unique_id}")
             assert state is not None
             assert state.name == unique_id
+
+
+async def test_appliance_switches(hass: HomeAssistant, mock_modbus_client, mock_config_entry):
+    """Test the appliance-level modbus switches (AP016 / AP028)."""
+
+    api = get_api(mock_modbus_client=mock_modbus_client)
+    with patch(
+        "custom_components.remeha_modbus.api.RemehaApi.create",
+        new=lambda *args, **kwargs: api,
+    ):
+        await setup_platform(hass=hass, config_entry=mock_config_entry)
+        await hass.async_block_till_done()
+
+        # Both are enabled in the modbus_store fixture (registers 500 and 502 are 1).
+        ch_enabled = hass.states.get("switch.remeha_modbus_test_hub_ch_enabled")
+        assert ch_enabled is not None
+        assert ch_enabled.state == "on"
+
+        cooling_enabled = hass.states.get("switch.remeha_modbus_test_hub_cooling_enabled")
+        assert cooling_enabled is not None
+        assert cooling_enabled.state == "on"
+
+        # Turning the switch off is reflected immediately.
+        await hass.services.async_call(
+            domain=SwitchDomain,
+            service="turn_off",
+            service_data={"entity_id": ch_enabled.entity_id},
+            blocking=True,
+        )
+
+        ch_enabled = hass.states.get(ch_enabled.entity_id)
+        assert ch_enabled is not None
+        assert ch_enabled.state == "off"


### PR DESCRIPTION
## Summary

Makes three appliance-level parameters that were previously read-only writable from Home Assistant. Requested for a Confida 50E, but these are generic GTW-08 appliance parameters (writable `par...` registers, same write path already used for forced cooling via the climate entity).

### `number` - Summer/winter threshold (AP073, register 386)

Outside-temperature limit above which the appliance switches to summer mode and stops heating. Range 10 - 30.5 degrees C in 0.5 degree steps.

### `switch` - Central heating (AP016, register 500)

Enables/disables central-heating demand processing (`ch_enabled`).

### `switch` - Cooling (AP028, register 502)

On selects active cooling, off disables cooling.

> The Confida indoor unit only offers *Off* / *Active cooling* for this parameter, so the switch maps to those two values. The register's `free cooling` value (used by geothermal/water-source systems) is intentionally not written by this switch.

All three entities are attached to the appliance mainboard device and write to the corresponding register via the existing `async_write_variable` path. Changes are reflected immediately and re-synced on the next coordinator refresh.

## Tests

Added tests for the new number entity (`test_summer_winter`) and the new switches (`test_appliance_switches`), and updated the number-entity count in `test_climates`.
